### PR TITLE
Correct requirementslib dependency issues 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ repos:
     name: "pipenv-setup sync with pipfile"
     stages: [push]
     language: system
-    entry: python -m pipenv_setup sync --pipfile
+    # --dev added to sync dev packages in pipfile with extras_require in setup.py
+    entry: python -m pipenv_setup sync --pipfile --dev
     pass_filenames: false
     always_run: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     name: "pipenv-setup sync with pipfile"
     stages: [push]
     language: system
-    types: [python]
     entry: python -m pipenv_setup sync --pipfile
     pass_filenames: false
     always_run: true
@@ -15,7 +14,6 @@ repos:
     name: "pipenv-setup check"
     stages: [push]
     language: system
-    types: [python]
     entry: python -m pipenv_setup check
     pass_filenames: false
     always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com/ for usage and config
+repos:
+- repo: https://github.com/anmut-consulting/pipenv-setup
+  rev: requirementslib_update
+  hooks:
+  - id: pipenv-setup-sync
+    name: "pipenv-setup sync with pipfile"
+    stages: [push]
+    language: system
+    entry: pipenv run pipenv-setup sync --pipfile
+    pass_filenames: false
+
+  - id: pipenv-setup-check
+    name: "pipenv-setup check"
+    stages: [push]
+    language: system
+    entry: pipenv run pipenv-setup check
+    pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 # See https://pre-commit.com/ for usage and config
 repos:
-- repo: https://github.com/anmut-consulting/pipenv-setup
-  rev: requirementslib_update
+- repo: local
   hooks:
   - id: pipenv-setup-sync
     name: "pipenv-setup sync with pipfile"
     stages: [push]
     language: system
-    entry: pipenv run pipenv-setup sync --pipfile
+    types: [python]
+    entry: python -m pipenv_setup sync --pipfile
     pass_filenames: false
     always_run: true
 
@@ -15,6 +15,7 @@ repos:
     name: "pipenv-setup check"
     stages: [push]
     language: system
-    entry: pipenv run pipenv-setup check
+    types: [python]
+    entry: python -m pipenv_setup check
     pass_filenames: false
     always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     language: system
     entry: pipenv run pipenv-setup sync --pipfile
     pass_filenames: false
+    always_run: true
 
   - id: pipenv-setup-check
     name: "pipenv-setup check"
@@ -16,3 +17,4 @@ repos:
     language: system
     entry: pipenv run pipenv-setup check
     pass_filenames: false
+    always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,7 @@
   entry: pipenv-setup sync
   language: python
   pass_filenames: false
+  always_run: true
 
 - id: pipenv-setup-check
   name: pipenv-setup-check
@@ -11,3 +12,4 @@
   entry: pipenv-setup check
   language: python
   pass_filenames: false
+  always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,6 @@
   entry: pipenv-setup sync
   language: python
   pass_filenames: false
-  always_run: true
 
 - id: pipenv-setup-check
   name: pipenv-setup-check
@@ -12,4 +11,3 @@
   entry: pipenv-setup check
   language: python
   pass_filenames: false
-  always_run: true

--- a/Pipfile
+++ b/Pipfile
@@ -21,10 +21,8 @@ six = "~=1.12"
 black = {version = "~=22.6" }
 autopep8 = "~=1.4"
 
-
 [scripts]
 # use this to sync this pipfile to setup.py, explained in CONTRIBUTING.md
 # `$ pipenv run sync-deps`
 sync-deps = 'python -m pipenv_setup sync --dev --pipfile'
 push_test = "pipenv run pre-commit run --hook-stage push"
-

--- a/Pipfile
+++ b/Pipfile
@@ -26,3 +26,5 @@ six = "~=1.12"
 # use this to sync this pipfile to setup.py, explained in CONTRIBUTING.md
 # `$ pipenv run sync-deps`
 sync-deps = 'python -m pipenv_setup sync --dev --pipfile'
+push_test = "pipenv run pre-commit run --hook-stage push"
+

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ autopep8 = "~=1.4"
 pipfile = "~=0.0"
 colorama = "~=0.4"
 packaging = "~=21.0"
-requirementslib = "~=2.1"
+#requirementslib = "~=2.1"
 typing = {version = "~=3.7"}
 six = "~=1.12"
 

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ verify_ssl = true
 
 [dev-packages]
 black = {version = "~=22.6" }
-#pipenv-setup = { editable = true, path = "." }
 pytest = {version = "~=7.1" }
 pytest-mypy = {version = "~=0.8" }
 pytest-cov = "~=3.0"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 black = {version = "~=22.6" }
-pipenv-setup = { editable = true, path = "." }
+#pipenv-setup = { editable = true, path = "." }
 pytest = {version = "~=7.1" }
 pytest-mypy = {version = "~=0.8" }
 pytest-cov = "~=3.0"
@@ -18,7 +18,7 @@ autopep8 = "~=1.4"
 pipfile = "~=0.0"
 colorama = "~=0.4"
 packaging = "~=21.0"
-#requirementslib = "~=2.1"
+requirementslib = "~=2.1"
 typing = {version = "~=3.7"}
 six = "~=1.12"
 

--- a/Pipfile
+++ b/Pipfile
@@ -4,14 +4,12 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-black = {version = "~=22.6" }
 pytest = {version = "~=7.1" }
 pytest-mypy = {version = "~=0.8" }
 pytest-cov = "~=3.0"
 pytest-datadir = "~=1.3"
 pytest-xdist = "~=2.0"
 tox = "~=3.24"
-autopep8 = "~=1.4"
 
 [packages]
 pipfile = "~=0.0"
@@ -20,6 +18,9 @@ packaging = "~=21.0"
 requirementslib = "~=2.1"
 typing = {version = "~=3.7"}
 six = "~=1.12"
+black = {version = "~=22.6" }
+autopep8 = "~=1.4"
+
 
 [scripts]
 # use this to sync this pipfile to setup.py, explained in CONTRIBUTING.md

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ autopep8 = "~=1.4"
 pipfile = "~=0.0"
 colorama = "~=0.4"
 packaging = "~=21.0"
-requirementslib = "~=1.5"
+requirementslib = "~=2.1"
 typing = {version = "~=3.7"}
 six = "~=1.12"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "caa65887acf90849d3704ad00eec55836089590ce66da18b466dcd19562860de"
+            "sha256": "a80e60f63a1c3b9d34f639886de8a35822c2e90bbe1ae8af177e5119d0743060"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -21,6 +21,41 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==22.1.0"
+        },
+        "autopep8": {
+            "hashes": [
+                "sha256:6f09e90a2be784317e84dc1add17ebfc7abe3924239957a37e5040e27d812087",
+                "sha256:ca9b1a83e53a7fad65d731dc7a2a2d50aa48f43850407c59f6a1a306c4201142"
+            ],
+            "index": "pypi",
+            "version": "==1.7.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7",
+                "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6",
+                "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650",
+                "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb",
+                "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d",
+                "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d",
+                "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de",
+                "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395",
+                "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae",
+                "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa",
+                "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef",
+                "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383",
+                "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66",
+                "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87",
+                "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d",
+                "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0",
+                "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b",
+                "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458",
+                "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4",
+                "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1",
+                "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"
+            ],
+            "index": "pypi",
+            "version": "==22.10.0"
         },
         "cached-property": {
             "hashes": [
@@ -51,6 +86,14 @@
             "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.1"
         },
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
+        },
         "colorama": {
             "hashes": [
                 "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
@@ -74,6 +117,13 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -81,6 +131,14 @@
             ],
             "index": "pypi",
             "version": "==21.3"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5",
+                "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.10.2"
         },
         "pep517": {
             "hashes": [
@@ -107,11 +165,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb",
-                "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"
+                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
+                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.3"
+            "version": "==2.5.4"
         },
         "plette": {
             "extras": [
@@ -123,6 +181,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.4.2"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
+                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.9.1"
         },
         "pyparsing": {
             "hashes": [
@@ -177,7 +243,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "tomlkit": {
@@ -221,49 +287,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==22.1.0"
-        },
-        "autopep8": {
-            "hashes": [
-                "sha256:6f09e90a2be784317e84dc1add17ebfc7abe3924239957a37e5040e27d812087",
-                "sha256:ca9b1a83e53a7fad65d731dc7a2a2d50aa48f43850407c59f6a1a306c4201142"
-            ],
-            "index": "pypi",
-            "version": "==1.7.0"
-        },
-        "black": {
-            "hashes": [
-                "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7",
-                "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6",
-                "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650",
-                "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb",
-                "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d",
-                "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d",
-                "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de",
-                "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395",
-                "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae",
-                "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa",
-                "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef",
-                "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383",
-                "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66",
-                "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87",
-                "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d",
-                "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0",
-                "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b",
-                "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458",
-                "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4",
-                "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1",
-                "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"
-            ],
-            "index": "pypi",
-            "version": "==22.10.0"
-        },
-        "click": {
-            "hashes": [
-                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
-                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.1.3"
         },
         "coverage": {
             "extras": [
@@ -333,11 +356,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a",
-                "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"
+                "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
+                "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.0.1"
+            "version": "==1.0.4"
         },
         "execnet": {
             "hashes": [
@@ -364,33 +387,39 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d",
-                "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24",
-                "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046",
-                "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e",
-                "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3",
-                "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5",
-                "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20",
-                "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda",
-                "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1",
-                "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146",
-                "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206",
-                "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746",
-                "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6",
-                "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e",
-                "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc",
-                "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a",
-                "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8",
-                "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763",
-                "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2",
-                "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947",
-                "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40",
-                "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b",
-                "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795",
-                "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"
+                "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d",
+                "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6",
+                "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf",
+                "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f",
+                "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813",
+                "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33",
+                "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad",
+                "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05",
+                "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297",
+                "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06",
+                "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd",
+                "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243",
+                "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305",
+                "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476",
+                "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711",
+                "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70",
+                "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5",
+                "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461",
+                "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab",
+                "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c",
+                "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d",
+                "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135",
+                "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93",
+                "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648",
+                "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a",
+                "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb",
+                "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3",
+                "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372",
+                "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb",
+                "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==0.982"
+            "markers": "python_version < '3.11' and python_version >= '3.9'",
+            "version": "==0.991"
         },
         "mypy-extensions": {
             "hashes": [
@@ -407,21 +436,13 @@
             "index": "pypi",
             "version": "==21.3"
         },
-        "pathspec": {
-            "hashes": [
-                "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93",
-                "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.10.1"
-        },
         "platformdirs": {
             "hashes": [
-                "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb",
-                "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"
+                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
+                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.3"
+            "version": "==2.5.4"
         },
         "pluggy": {
             "hashes": [
@@ -438,14 +459,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.11.0"
-        },
-        "pycodestyle": {
-            "hashes": [
-                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
-                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.9.1"
         },
         "pyparsing": {
             "hashes": [
@@ -489,11 +502,11 @@
         },
         "pytest-mypy": {
             "hashes": [
-                "sha256:83843dce75a7ce055efb264ff40dad2ecf7abd4e7bd5e5eda015261d11616abb",
-                "sha256:e74d632685f15a39c31c551a9d8cec4619e24bd396245a6335c5db0ec6d17b6f"
+                "sha256:7fe68837449334553e224cc86c6dc1b938772399abb64f510a864fb209593a94",
+                "sha256:ecf541a28df9e5f992936a1613bee231957df2d40efa662cd7c52ace2e64f43f"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "pytest-xdist": {
             "hashes": [
@@ -511,29 +524,21 @@
             "index": "pypi",
             "version": "==1.16.0"
         },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2"
-        },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "tox": {
             "hashes": [
-                "sha256:89e4bc6df3854e9fc5582462e328dd3660d7d865ba625ae5881bbc63836a6324",
-                "sha256:d2c945f02a03d4501374a3d5430877380deb69b218b1df9b7f1d2f2a10befaf9"
+                "sha256:b2a920e35a668cc06942ffd1cf3a4fb221a4d909ca72191fb6d84b0b18a7be04",
+                "sha256:f52ca66eae115fcfef0e77ef81fd107133d295c97c52df337adedb8dfac6ab84"
             ],
             "index": "pypi",
-            "version": "==3.27.0"
+            "version": "==3.27.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -545,11 +550,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108",
-                "sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e"
+                "sha256:8691e3ff9387f743e00f6bb20f70121f5e4f596cae754531f2b3b3a1b1ac696e",
+                "sha256:efd66b00386fdb7dbe4822d172303f40cd05e50e01740b19ea42425cbe653e29"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==20.16.6"
+            "version": "==20.16.7"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "624f884b9c2395d61391f7f2a4f6ba2c3cb8da15171d7eb031e2ae5d94fc3b71"
+            "sha256": "caa65887acf90849d3704ad00eec55836089590ce66da18b466dcd19562860de"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -74,13 +74,6 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
-        "orderedmultidict": {
-            "hashes": [
-                "sha256:04070bbb5e87291cc9bfa51df413677faf2141c73c61d2a5f7b26bea3cd882ad",
-                "sha256:43c839a17ee3cdd62234c47deca1a8508a3f2ca1d0678a3bf791c87cf84adbf3"
-            ],
-            "version": "==1.0.1"
-        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -99,19 +92,11 @@
         },
         "pip": {
             "hashes": [
-                "sha256:1daab4b8d3b97d1d763caeb01a4640a2250a0ea899e257b1e44b9eded91e15ab",
-                "sha256:8182aec21dad6c0a49a2a3d121a87cd524b950e0b6092b181625f07ebdde7530"
+                "sha256:65fd48317359f3af8e593943e6ae1506b66325085ea64b706a998c6e83eeaf38",
+                "sha256:908c78e6bc29b676ede1c4d57981d490cb892eb45cd8c214ab6298125119e077"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==22.3"
-        },
-        "pip-shims": {
-            "hashes": [
-                "sha256:089e3586a92b1b8dbbc16b2d2859331dc1c412d3e3dbcd91d80e6b30d73db96c",
-                "sha256:2ae9f21c0155ca5c37d2734eb5f9a7d98c4c42a122d1ba3eddbacc9d9ea9fbae"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.7.3"
+            "version": "==22.3.1"
         },
         "pipfile": {
             "hashes": [
@@ -122,11 +107,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
-                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+                "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb",
+                "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.2"
+            "version": "==2.5.3"
         },
         "plette": {
             "extras": [
@@ -141,19 +126,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
         },
         "requests": {
             "hashes": [
@@ -165,19 +142,19 @@
         },
         "requirementslib": {
             "hashes": [
-                "sha256:28924cf11a2fa91adb03f8431d80c2a8c3dc386f1c48fb2be9a58e4c39072354",
-                "sha256:d26ec6ad45e1ffce9532303543996c9c71a99dc65f783908f112e3f2aae7e49c"
+                "sha256:09f86c3ed61b3fe65b7c2c6afae4e6266f0099841118cf51af455b58bb1cad06",
+                "sha256:b7f9541b3a6b8fbd49e7e58988d9476341b73e3c5e94d48a3ee1bc927e49e5bc"
             ],
             "index": "pypi",
-            "version": "==1.6.9"
+            "version": "==2.1.0"
         },
         "setuptools": {
             "hashes": [
-                "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17",
-                "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"
+                "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31",
+                "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.5.0"
+            "version": "==65.5.1"
         },
         "six": {
             "hashes": [
@@ -205,11 +182,11 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:571854ebbb5eac89abcb4a2e47d7ea27b89bf29e09c35395da6f03dd4ae23d1c",
-                "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"
+                "sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
+                "sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "version": "==0.11.5"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.11.6"
         },
         "typing": {
             "hashes": [
@@ -229,19 +206,11 @@
         },
         "vistir": {
             "hashes": [
-                "sha256:9834e32a3db84894c92c4f35b85b6d30f6d89f557a3532cc5c5d115709f52fec",
-                "sha256:f2827f3fb0572ffef9d7f3d2bd0c064913ba16cdfe19763f4051b69477c9f9cd"
+                "sha256:1a89a612fb667c26ed6b4ed415b01e0261e13200a350c43d1990ace0ef44d35b",
+                "sha256:a8beb7643d07779cdda3941a08dad77d48de94883dbd3cb2b9b5ecb7eb7c0994"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.7.0"
-        },
-        "wheel": {
-            "hashes": [
-                "sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a",
-                "sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.37.1"
+            "markers": "python_version not in '3.0, 3.1, 3.2, 3.3' and python_version >= '3.7'",
+            "version": "==0.6.1"
         }
     },
     "develop": {
@@ -288,35 +257,6 @@
             "index": "pypi",
             "version": "==22.10.0"
         },
-        "cached-property": {
-            "hashes": [
-                "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130",
-                "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"
-            ],
-            "version": "==1.5.2"
-        },
-        "cerberus": {
-            "hashes": [
-                "sha256:d1b21b3954b2498d9a79edf16b3170a3ac1021df88d197dc2ce5928ba519237c"
-            ],
-            "version": "==1.3.4"
-        },
-        "certifi": {
-            "hashes": [
-                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
-        },
-        "charset-normalizer": {
-            "hashes": [
-                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
-            ],
-            "markers": "python_full_version >= '3.6.0'",
-            "version": "==2.1.1"
-        },
         "click": {
             "hashes": [
                 "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
@@ -324,14 +264,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "index": "pypi",
-            "version": "==0.4.6"
         },
         "coverage": {
             "extras": [
@@ -401,11 +333,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337",
-                "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"
+                "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a",
+                "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.0.0rc9"
+            "version": "==1.0.1"
         },
         "execnet": {
             "hashes": [
@@ -422,14 +354,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.8.0"
-        },
-        "idna": {
-            "hashes": [
-                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.4"
         },
         "iniconfig": {
             "hashes": [
@@ -475,13 +399,6 @@
             ],
             "version": "==0.4.3"
         },
-        "orderedmultidict": {
-            "hashes": [
-                "sha256:04070bbb5e87291cc9bfa51df413677faf2141c73c61d2a5f7b26bea3cd882ad",
-                "sha256:43c839a17ee3cdd62234c47deca1a8508a3f2ca1d0678a3bf791c87cf84adbf3"
-            ],
-            "version": "==1.0.1"
-        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -498,59 +415,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==0.10.1"
         },
-        "pep517": {
-            "hashes": [
-                "sha256:4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b",
-                "sha256:ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.13.0"
-        },
-        "pip": {
-            "hashes": [
-                "sha256:1daab4b8d3b97d1d763caeb01a4640a2250a0ea899e257b1e44b9eded91e15ab",
-                "sha256:8182aec21dad6c0a49a2a3d121a87cd524b950e0b6092b181625f07ebdde7530"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==22.3"
-        },
-        "pip-shims": {
-            "hashes": [
-                "sha256:089e3586a92b1b8dbbc16b2d2859331dc1c412d3e3dbcd91d80e6b30d73db96c",
-                "sha256:2ae9f21c0155ca5c37d2734eb5f9a7d98c4c42a122d1ba3eddbacc9d9ea9fbae"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.7.3"
-        },
-        "pipenv-setup": {
-            "editable": true,
-            "path": "."
-        },
-        "pipfile": {
-            "hashes": [
-                "sha256:f7d9f15de8b660986557eb3cc5391aa1a16207ac41bc378d03f414762d36c984"
-            ],
-            "index": "pypi",
-            "version": "==0.0.2"
-        },
         "platformdirs": {
             "hashes": [
-                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
-                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+                "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb",
+                "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.2"
-        },
-        "plette": {
-            "extras": [
-                "validation"
-            ],
-            "hashes": [
-                "sha256:7bf014ff695d8badf5a058227db0f0bd1fa7ffd6e54ad8b851bc36c20a4a7894",
-                "sha256:e4dc4a05bfce68d6f6b8d1ccd6e8957ecf4ed6707e8d32f7188b6e628526644e"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.4.2"
+            "version": "==2.5.3"
         },
         "pluggy": {
             "hashes": [
@@ -578,11 +449,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
@@ -632,38 +503,6 @@
             "index": "pypi",
             "version": "==2.5.0"
         },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
-        },
-        "requests": {
-            "hashes": [
-                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
-                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
-            ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
-            "version": "==2.28.1"
-        },
-        "requirementslib": {
-            "hashes": [
-                "sha256:28924cf11a2fa91adb03f8431d80c2a8c3dc386f1c48fb2be9a58e4c39072354",
-                "sha256:d26ec6ad45e1ffce9532303543996c9c71a99dc65f783908f112e3f2aae7e49c"
-            ],
-            "index": "pypi",
-            "version": "==1.6.9"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17",
-                "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==65.5.0"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -688,29 +527,13 @@
             "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
-        "tomlkit": {
-            "hashes": [
-                "sha256:571854ebbb5eac89abcb4a2e47d7ea27b89bf29e09c35395da6f03dd4ae23d1c",
-                "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"
-            ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "version": "==0.11.5"
-        },
         "tox": {
             "hashes": [
-                "sha256:44f3c347c68c2c68799d7d44f1808f9d396fc8a1a500cbc624253375c7ae107e",
-                "sha256:bf037662d7c740d15c9924ba23bb3e587df20598697bb985ac2b49bdc2d847f6"
+                "sha256:89e4bc6df3854e9fc5582462e328dd3660d7d865ba625ae5881bbc63836a6324",
+                "sha256:d2c945f02a03d4501374a3d5430877380deb69b218b1df9b7f1d2f2a10befaf9"
             ],
             "index": "pypi",
-            "version": "==3.26.0"
-        },
-        "typing": {
-            "hashes": [
-                "sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9",
-                "sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5"
-            ],
-            "index": "pypi",
-            "version": "==3.7.4.3"
+            "version": "==3.27.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -720,37 +543,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==4.4.0"
         },
-        "urllib3": {
-            "hashes": [
-                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
-                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.12"
-        },
         "virtualenv": {
             "hashes": [
-                "sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da",
-                "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"
+                "sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108",
+                "sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==20.16.5"
-        },
-        "vistir": {
-            "hashes": [
-                "sha256:9834e32a3db84894c92c4f35b85b6d30f6d89f557a3532cc5c5d115709f52fec",
-                "sha256:f2827f3fb0572ffef9d7f3d2bd0c064913ba16cdfe19763f4051b69477c9f9cd"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.7.0"
-        },
-        "wheel": {
-            "hashes": [
-                "sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a",
-                "sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.37.1"
+            "version": "==20.16.6"
         }
     }
 }

--- a/pipenv_setup/inconsistency_checker.py
+++ b/pipenv_setup/inconsistency_checker.py
@@ -239,7 +239,14 @@ class InconsistencyChecker:
         met_comp_ops = False
 
         for c in package_string:
-            if c in ("=", "<", ">", "!"):
+            # Discovered 09/11/2022 that pipfile sync checks will fail if tilde
+            # is not properly handled when checking pipfile syncing and 'at
+            # least' notation is used (pipfile~=0.1 as opposed to pipfile==0.1).
+            # This means that name and version_reqs_string are returned
+            # incorrectly e.g.
+            # name = 'pipfile~', version_reqs_string =  '=0.0'     instead of
+            # name = 'pipfile',  version_reqs_string = '~=0.0'
+            if c in ("=", "<", ">", "!", "~"):
                 met_comp_ops = True
             elif c == ";":  # met other markers, which we ignore
                 break

--- a/pipenv_setup/inconsistency_checker.py
+++ b/pipenv_setup/inconsistency_checker.py
@@ -245,13 +245,6 @@ class InconsistencyChecker:
         met_comp_ops = False
 
         for c in package_string:
-            # Discovered 09/11/2022 that pipfile sync checks will fail if tilde
-            # is not properly handled when checking pipfile syncing and 'at
-            # least' notation is used (pipfile~=0.1 as opposed to pipfile==0.1).
-            # This means that name and version_reqs_string are returned
-            # incorrectly e.g.
-            # name = 'pipfile~', version_reqs_string =  '=0.0'     instead of
-            # name = 'pipfile',  version_reqs_string = '~=0.0'
             if c in ("=", "<", ">", "!", "~"):
                 met_comp_ops = True
             elif c == ";":  # met other markers, which we ignore

--- a/pipenv_setup/inconsistency_checker.py
+++ b/pipenv_setup/inconsistency_checker.py
@@ -232,6 +232,12 @@ class InconsistencyChecker:
         ('numpy', '==1.2.3,>1.2,<2')
         >>> InconsistencyChecker._separate_name_version("numpy")
         ('numpy', '')
+        >>> InconsistencyChecker._separate_name_version("numpy~=1.2.3")
+        ('numpy', '~=1.2.3')
+        >>> InconsistencyChecker._separate_name_version("numpy~=1.2.3, >1.2,<2")
+        ('numpy', '~=1.2.3,>1.2,<2')
+        >>> InconsistencyChecker._separate_name_version("numpy~=1.2.3, >1.2,<2; os_name='nt'")
+        ('numpy', '~=1.2.3,>1.2,<2')
         """
         name = ""
         version_reqs_string = ""

--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -176,8 +176,10 @@ def check(args):
         setup_code = setup_file.read()
     try:
         (
+            #TODO: return the extras_require nodes from setup.py, and update below to check with pipfile using inconsistency checker
             install_requires,
             dependency_links,
+            # extras_require,
         ) = setup_parser.get_install_requires_dependency_links(setup_code)
     except (ValueError, SyntaxError) as e:
         fatal_error(str(e))
@@ -194,6 +196,8 @@ def check(args):
         checker.check_dependency_links_conflict,
         checker.check_lacking_install_requires,
         checker.check_lacking_dependency_links,
+        #checker.check_extras_require_conflict
+        #checker.check_lacking_extras_require
     )
     for check_item in checks:
         try:

--- a/setup.py
+++ b/setup.py
@@ -137,14 +137,12 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     extras_require={
         "dev": [
-            "black~=22.6",
             "pytest~=7.1",
             "pytest-mypy~=0.8",
             "pytest-cov~=3.0",
             "pytest-datadir~=1.3",
             "pytest-xdist~=2.0",
             "tox~=3.24",
-            "autopep8~=1.4",
         ]
     },
     install_requires=[
@@ -154,6 +152,8 @@ setup(
         "requirementslib~=2.1",
         "typing~=3.7",
         "six~=1.12",
+        "black~=22.6",
+        "autopep8~=1.4",
     ],  # Optional
     entry_points={
         "console_scripts": ["pipenv-setup=pipenv_setup.main:cmd"]

--- a/setup.py
+++ b/setup.py
@@ -136,25 +136,25 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     extras_require={
-        "dev": ['black~=22.6', 'pytest~=7.1', 'pytest-mypy~=0.8', 'pytest-cov~=3.0', 'pytest-datadir~=1.3', 'pytest-xdist~=2.0', 'tox~=3.24', 'autopep8~=1.4',
-
-
-
-
-
-
-
-
-]
+        "dev": [
+            "black~=22.6",
+            "pytest~=7.1",
+            "pytest-mypy~=0.8",
+            "pytest-cov~=3.0",
+            "pytest-datadir~=1.3",
+            "pytest-xdist~=2.0",
+            "tox~=3.24",
+            "autopep8~=1.4",
+        ]
     },
-    install_requires=['pipfile~=0.0', 'colorama~=0.4', 'packaging~=21.0', 'requirementslib~=2.1', 'typing~=3.7', 'six~=1.12'
-
-
-
-
-
-
-],  # Optional
+    install_requires=[
+        "pipfile~=0.0",
+        "colorama~=0.4",
+        "packaging~=21.0",
+        "requirementslib~=2.1",
+        "typing~=3.7",
+        "six~=1.12",
+    ],  # Optional
     entry_points={
         "console_scripts": ["pipenv-setup=pipenv_setup.main:cmd"]
     },  # Optional

--- a/setup.py
+++ b/setup.py
@@ -150,9 +150,8 @@ setup(
         "pipfile~=0.0",
         "colorama~=0.4",
         "packaging~=21.0",
-        "requirementslib~=1.5",
+        "requirementslib~=2.1",
         "typing~=3.7",
-        "vistir~=0.4",
         "six~=1.12",
     ],  # Optional
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
+    dependency_links=[],
     # This field adds keywords for your project which will appear on the
     # project page. What does your project relate to?
     #

--- a/setup.py
+++ b/setup.py
@@ -146,14 +146,14 @@ setup(
             "autopep8~=1.4",
         ]
     },
-    install_requires=[
-        "pipfile~=0.0",
-        "colorama~=0.4",
-        "packaging~=21.0",
-        "requirementslib~=2.1",
-        "typing~=3.7",
-        "six~=1.12",
-    ],  # Optional
+    install_requires=['pipfile~=0.0', 'colorama~=0.4', 'packaging~=21.0', 'requirementslib~=2.1', 'typing~=3.7', 'six~=1.12'
+
+
+
+
+
+
+],  # Optional
     entry_points={
         "console_scripts": ["pipenv-setup=pipenv_setup.main:cmd"]
     },  # Optional

--- a/setup.py
+++ b/setup.py
@@ -135,16 +135,16 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     extras_require={
-        "dev": [
-            "black~=22.6",
-            "pytest~=7.1",
-            "pytest-mypy~=0.8",
-            "pytest-cov~=3.0",
-            "pytest-datadir~=1.3",
-            "pytest-xdist~=2.0",
-            "tox~=3.24",
-            "autopep8~=1.4",
-        ]
+        "dev": ['black~=22.6', 'pytest~=7.1', 'pytest-mypy~=0.8', 'pytest-cov~=3.0', 'pytest-datadir~=1.3', 'pytest-xdist~=2.0', 'tox~=3.24', 'autopep8~=1.4',
+
+
+
+
+
+
+
+
+]
     },
     install_requires=['pipfile~=0.0', 'colorama~=0.4', 'packaging~=21.0', 'requirementslib~=2.1', 'typing~=3.7', 'six~=1.12'
 

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
     # This field corresponds to the "Project-URL" metadata fields:
     # https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use
     project_urls={  # Optional
-        # "Bug Reports": "https://github.com/anmut-consulting/pipenv-setup/issues",
+        "Bug Reports": "https://github.com/anmut-consulting/pipenv-setup/issues",
         "Source": "https://github.com/anmut-consulting/pipenv-setup",
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="3.1.1",  # Required
+    version="3.1.5",  # Required
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
@@ -71,13 +71,13 @@ setup(
     #
     # This field corresponds to the "Home-Page" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#home-page-optional
-    url="https://github.com/Madoshakalaka/pipenv-setup",  # Optional
+    url="https://github.com/anmut-consulting/pipenv-setup",  # Optional
     # This should be your name or the name of the organization which owns the
     # project.
-    author="Matt Yan",  # Optional
+    author="Anmut",  # Optional
     # This should be a valid email address corresponding to the author listed
     # above.
-    author_email="syan4@ualberta.ca",  # Optional
+    author_email="systems@anmut.co.uk",  # Optional
     # Classifiers help users find your project by categorizing it.
     #
     # For a list of valid classifiers, see https://pypi.org/classifiers/
@@ -162,8 +162,7 @@ setup(
     # This field corresponds to the "Project-URL" metadata fields:
     # https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use
     project_urls={  # Optional
-        "Bug Reports": "https://github.com/Madoshakalaka/pipenv-setup/issues",
-        "Say Thanks!": "https://github.com/Madoshakalaka/pipenv-setup",
-        "Source": "https://github.com/Madoshakalaka/pipenv-setup",
+        # "Bug Reports": "https://github.com/anmut-consulting/pipenv-setup/issues",
+        "Source": "https://github.com/anmut-consulting/pipenv-setup",
     },
 )


### PR DESCRIPTION
Our fork of pipenv-setup currently specifies requirementslib version ~1.5, and so the pipenv environment is currently locked to requirementslib 1.6.9. This version of requirementslib relies on the recently removed Vistir compat module, which breaks pipenv-setup functionality.

Additionally, the upstream pipenv-setup contains a bug in the functionality when syncing setup.py to a pipfile.lock file, as it cannot recognise tilde notation e.g. pipenv~=1.1.2.

Finally, pipenv-setup is used to sync its own setup.py files with its pipfile, which means that if a breaking change is introduced in a dependency, the entire project will break.